### PR TITLE
Wait for iodine to shutdown...

### DIFF
--- a/spec/integrations/server_spec.rb
+++ b/spec/integrations/server_spec.rb
@@ -135,6 +135,7 @@ context 'IodineServer', :async, if: ENV['IODINE'] do
 
     after(:all) do
       Iodine.stop
+      @server.join # Iodine.stop is asynchronous, wait fot the server to shutdown.
     end
   end
 end


### PR DESCRIPTION
Iodine is asynchronous, which means that it's still running (performing the shutdown) when `Iodine.stop` returns.

This means that the Iodine server thread might be in a critical section (i.e., holding  the GC lock) when it is terminated abnormally after the test.

To avoid the server's thread being terminated abnormally, it is better to join it.